### PR TITLE
Box-sizing style fix to ‘content-box’

### DIFF
--- a/css/styledLayerControl.css
+++ b/css/styledLayerControl.css
@@ -52,6 +52,7 @@
 		0px 0px 0px 1px rgba(155,155,155,0.3), 
 		1px 0px 0px 0px rgba(255,255,255,0.9) inset, 
 		0px 2px 2px rgba(0,0,0,0.1);
+    box-sizing: content-box;
 }
 .ac-container label:hover{
 	background: #fff;


### PR DESCRIPTION
This should be specified to avoid conflicting with bootstrap's
scaffolding.less that defaults the border-box to box-sizing.