### PR TITLE
Bugfix for reentering of deleted layers

### DIFF
--- a/src/styledLayerControl.js
+++ b/src/styledLayerControl.js
@@ -376,7 +376,7 @@ L.Control.StyledLayerControl = L.Control.Layers.extend({
 			if( this._map.hasLayer(n_obj.layer) ){
 				this._map.removeLayer(n_obj.layer);
 			}
-			
+			this.removeLayer(n_obj.layer); 
 			obj.target.parentNode.remove();
 			
 			return false;


### PR DESCRIPTION
If layers are deleted via the delete button, they disappear. If new layers are added dynamically they do reappear however. If a call to this.removeLayer is made, the subsequent call to this._update() does not include the deleted layer.