### PR TITLE
New functionalities and tweaks

### DIFF
--- a/css/styledLayerControl.css
+++ b/css/styledLayerControl.css
@@ -22,12 +22,12 @@
 
 .ac-container{
 	width: auto;
-	margin: 10px auto 10px auto;
 	text-align: left;
 	overflow-y: auto;
 	overflow-x: hidden;
 	height: auto;
 }
+
 div[id^="leaflet-control-accordion-layers"] > label {
 	font-family: 'BebasNeueRegular', 'Arial Narrow', Arial, sans-serif;
 	padding: 5px 20px;
@@ -55,6 +55,7 @@ div[id^="leaflet-control-accordion-layers"] > label {
     box-sizing: content-box;
     cursor:pointer;
     width: auto;
+    margin: 0;
 }
 div[id^="leaflet-control-accordion-layers"] > label:hover {
 	background: #fff;
@@ -89,6 +90,7 @@ div[id^="leaflet-control-accordion-layers"] > label:hover {
 	margin-top: -1px;
 	overflow: hidden;
 	height: 0px;
+    padding: 0px;
     line-height: 0px;
 	position: relative;
 	z-index: 10;
@@ -105,13 +107,12 @@ div[id^="leaflet-control-accordion-layers"] > label:hover {
 	-o-transition: height 0.5s ease-in-out, box-shadow 0.1s linear;
 	-ms-transition: height 0.5s ease-in-out, box-shadow 0.1s linear;
 	transition: height 0.5s ease-in-out, box-shadow 0.1s linear;
-	box-shadow: 0px 0px 0px 1px rgba(155,155,155,0.3);
 }
 
 .ac-container input.menu:checked ~ article.ac-large{
 	height: auto;
 	max-height : 100px;
-	padding-top: 5px;
+	padding: 8px 0;
 	overflow-y: auto;
     line-height: 18px;
 }
@@ -119,6 +120,19 @@ div[id^="leaflet-control-accordion-layers"] > label:hover {
 .ac-container article label {
     display: inline;
     cursor: pointer;
+}
+
+.ac-container .group-toggle-container {
+    text-align: right;
+    margin-right: 3px;
+    line-height: 0px;
+    display: none;
+    height: 20px;
+}
+
+.ac-container input.menu:checked ~ .group-toggle-container {
+    display: block;
+	line-height: 1em;
 }
 
 .menu-item-radio{
@@ -145,6 +159,10 @@ div[id^="leaflet-control-accordion-layers"] > label:hover {
     height: 16px;
     width: 16px;
     vertical-align: middle;
+}
+
+.leaflet-control-layers-expanded {
+    padding: 5px;
 }
 
 .leaflet-control-layers:hover {

--- a/css/styledLayerControl.css
+++ b/css/styledLayerControl.css
@@ -28,7 +28,7 @@
 	overflow-x: hidden;
 	height: auto;
 }
-.ac-container label{
+div[id^="leaflet-control-accordion-layers"] > label {
 	font-family: 'BebasNeueRegular', 'Arial Narrow', Arial, sans-serif;
 	padding: 5px 20px;
 	position: relative;
@@ -48,13 +48,15 @@
 	background: -ms-linear-gradient(top, #ffffff 1%,#eaeaea 100%);
 	background: linear-gradient(top, #ffffff 1%,#eaeaea 100%);
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#eaeaea',GradientType=0 );
-	box-shadow: 
-		0px 0px 0px 1px rgba(155,155,155,0.3), 
-		1px 0px 0px 0px rgba(255,255,255,0.9) inset, 
+	box-shadow:
+		0px 0px 0px 1px rgba(155,155,155,0.3),
+		1px 0px 0px 0px rgba(255,255,255,0.9) inset,
 		0px 2px 2px rgba(0,0,0,0.1);
     box-sizing: content-box;
+    cursor:pointer;
+    width: auto;
 }
-.ac-container label:hover{
+div[id^="leaflet-control-accordion-layers"] > label:hover {
 	background: #fff;
 }
 .ac-container input.menu:checked + label,
@@ -62,21 +64,21 @@
 	background: #c6e1ec;
 	color: #3d7489;
 	text-shadow: 0px 1px 1px rgba(255,255,255, 0.6);
-	box-shadow: 
-		0px 0px 0px 1px rgba(155,155,155,0.3), 
+	box-shadow:
+		0px 0px 0px 1px rgba(155,155,155,0.3),
 		0px 2px 2px rgba(0,0,0,0.1);
 }
-.ac-container label:hover:after,
-.ac-container input.menu:checked + label:hover:after{
+.ac-container div[id^="leaflet-control-accordion-layers"] > label:hover:after,
+.ac-container input.menu:checked + div[id^="leaflet-control-accordion-layers"] > label:hover:after{
 	content: '';
 	position: absolute;
 	width: 24px;
 	height: 24px;
 	right: 13px;
 	top: 7px;
-	background: transparent url(images/arrow_down.png) no-repeat center center;	
+	background: transparent url(images/arrow_down.png) no-repeat center center;
 }
-.ac-container input.menu:checked + label:hover:after{
+.ac-container input.menu:checked + div[id^="leaflet-control-accordion-layers"] > label:hover:after{
 	background-image: url(images/arrow_up.png);
 }
 .ac-container input.menu{
@@ -87,6 +89,7 @@
 	margin-top: -1px;
 	overflow: hidden;
 	height: 0px;
+    line-height: 0px;
 	position: relative;
 	z-index: 10;
 	-webkit-transition: height 0.3s ease-in-out, box-shadow 0.6s linear;
@@ -110,32 +113,38 @@
 	max-height : 100px;
 	padding-top: 5px;
 	overflow-y: auto;
+    line-height: 18px;
+}
+
+.ac-container article label {
+    display: inline;
+    cursor: pointer;
 }
 
 .menu-item-radio{
 	font-family: 'Ubuntu-Regular', Arial, sans-serif;
 	font-size: 13px;
-	
+
 }
 
 .menu-item-checkbox{
 	font-family: 'Ubuntu-Regular', Arial, sans-serif;
 	font-size: 13px;
-	
+
 }
 
 .bt_delete{
     position: relative;
 	float: right;
-	background-image: url(images/delete.png); 
-    background-color: transparent; 
-    background-repeat: no-repeat;  
-    background-position: 0px 0px;  
-    border: none;           
-    cursor: pointer;        
-    height: 16px;   
-    width: 16px;	
-    vertical-align: middle; 
+	background-image: url(images/delete.png);
+    background-color: transparent;
+    background-repeat: no-repeat;
+    background-position: 0px 0px;
+    border: none;
+    cursor: pointer;
+    height: 16px;
+    width: 16px;
+    vertical-align: middle;
 }
 
 .leaflet-control-layers:hover {
@@ -143,6 +152,3 @@
 	background: #e0e3ec url(images/bgnoise_lg.jpg) repeat top left;
 	border-radius: 5px;
 }
-
-
-

--- a/src/styledLayerControl.js
+++ b/src/styledLayerControl.js
@@ -92,6 +92,21 @@ L.Control.StyledLayerControl = L.Control.Layers.extend({
         }
     },
 
+    removeAllGroups: function(del) {
+        for (group in this._groupList) {
+                for (layer in this._layers) {
+                    if (this._layers[layer].group && this._layers[layer].group.removable) {
+                        if (del) {
+                            this._map.removeLayer(this._layers[layer].layer);
+                        }
+                        delete this._layers[layer];
+                    }
+                }
+                delete this._groupList[group];
+        }
+        this._update();
+    },
+
     selectLayer: function(layer) {
         this._map.addLayer(layer);
         this._update();

--- a/src/styledLayerControl.js
+++ b/src/styledLayerControl.js
@@ -74,11 +74,14 @@ L.Control.StyledLayerControl = L.Control.Layers.extend({
         return this;
     },
 
-    removeGroup: function(group_Name) {
+    removeGroup: function(group_Name, del) {
         for (group in this._groupList) {
             if (this._groupList[group].groupName == group_Name) {
                 for (layer in this._layers) {
                     if (this._layers[layer].group && this._layers[layer].group.name == group_Name) {
+                        if (del) {
+                            this._map.removeLayer(this._layers[layer].layer);
+                        }
                         delete this._layers[layer];
                     }
                 }
@@ -256,6 +259,7 @@ L.Control.StyledLayerControl = L.Control.Layers.extend({
 
         this._baseLayersList.innerHTML = '';
         this._overlaysList.innerHTML = '';
+
         this._domGroups.length = 0;
 
         var baseLayersPresent = false,
@@ -553,7 +557,7 @@ L.Control.StyledLayerControl = L.Control.Layers.extend({
     },
 
     _onRemoveGroup: function(e) {
-        this.removeGroup(e.target.getAttribute("data-group-name"));
+        this.removeGroup(e.target.getAttribute("data-group-name"), true);
     },
 
     _expand: function() {


### PR DESCRIPTION
- Ability to click on a layer name to toggle the layer visibility
- Enable or disable radio/checkbox if layer option minZoom or maxZoom matches.
- Buttons to enable / disable all layers on a group.
- Button to delete a group
- Fixed bug on leaflet 0.7.7 getting map size when container_maxHeight was not set. 
- Some css tweaks

**Main plugin new options:**

group_togglers: {
  show: true, // Display the links
  labelAll: 'All', // Label for button to display all layers of the group
  labelNone: 'None' // Label for button to hide all layers of the group
},
group_groupDeleteLabel: 'Delete the group' // Label for the group delete button

**addOverlay function new options:**

removable: true/false to show/hide the button for group deletion.
