### PR TITLE
Fix an issue with 'container_maxHeight'

### DIFF
--- a/src/styledLayerControl.js
+++ b/src/styledLayerControl.js
@@ -204,7 +204,7 @@ L.Control.StyledLayerControl = L.Control.Layers.extend({
 
             // set the max-height of control to y value of map object
             this._default_maxHeight = this.options.container_maxHeight ? this.options.container_maxHeight : (this._map.getSize().y - 70);
-            containers[c].style.maxHeight = this._default_maxHeight + "px";
+            containers[c].style.maxHeight = this._default_maxHeight;
 
         }
 


### PR DESCRIPTION
The `container_maxHeight` option was not working properly, because `px` was appended after a value that already contained `px` and then the resulting value (like `350pxpx`) added to the DOM. Such value is indeed invalid and and then ignored by the browser.

```javascript
	var options = {
		container_width 	: "300px",
		container_maxHeight : "350px", 
		group_maxHeight     : "80px",
		exclusive       	: false
	};
```
The behavior was fixed by a resize of the window because the algorithm triggered by the `resize` event was actually correct.
